### PR TITLE
Appease GCC's 'return-type' warning

### DIFF
--- a/src/hulp.c
+++ b/src/hulp.c
@@ -660,6 +660,7 @@ static int print_insn(const ulp_insn_t *ins)
             assert(0 && "unknown opcode");
     }
     assert(0);
+    return 0;
 }
 
 void hulp_dump_program(uint32_t start_offset, size_t num_instructions)

--- a/src/hulp.c
+++ b/src/hulp.c
@@ -659,8 +659,7 @@ static int print_insn(const ulp_insn_t *ins)
         default:
             assert(0 && "unknown opcode");
     }
-    assert(0);
-    return 0;
+    abort();
 }
 
 void hulp_dump_program(uint32_t start_offset, size_t num_instructions)


### PR DESCRIPTION
GCC isn't smart enough that if we get to the assert the return value doesn't matter anyways and raises a `control reaches end of non-void function` warning. This is especially a bummer when treating warnings as errors (which I think is the ESP-IDF 4.4 default)

```
embedded-app/components/HULP/src/hulp.c: In function 'print_insn':
embedded-app/components/HULP/src/hulp.c:663:1: error: control reaches end of non-void function [-Werror=return-type]
 }
 ^
cc1: some warnings being treated as errors
```