### PR TITLE
Remove warning at HULP_LBLA

### DIFF
--- a/src/hulp_macros.h
+++ b/src/hulp_macros.h
@@ -33,7 +33,7 @@
  */
 #define HULP_LBLA() ({ \
             TRY_STATIC_ASSERT(__LINE__ <= (UINT16_MAX - CONFIG_HULP_LABEL_AUTO_BASE), (Auto label overflow)); \
-            (CONFIG_HULP_LABEL_AUTO_BASE + __LINE__); \
+            ((uint32_t)CONFIG_HULP_LABEL_AUTO_BASE + __LINE__); \
         })
 
 /**


### PR DESCRIPTION
Hi @boarchuz ,
i get this warning when using HULP_LBLA().

```
.pio/libdeps/pico32/HULP/src/hulp_macros.h:36:54: warning: narrowing conversion of '({...})' from 'int' to 'uint32_t' {aka 'unsigned int'} inside { } [-Wnarrowing]
             ( CONFIG_HULP_LABEL_AUTO_BASE + __LINE__); \
                                                      ^
```
See Issue #34 